### PR TITLE
feat: Enable AI to execute commands in the terminal

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -14,10 +14,21 @@ export type Intent =
 	| { type: 'gitStatus' }
 	| { type: 'gitCommit'; message: string }
 	| { type: 'gitPush' }
+	| { type: 'runInTerminal'; command: string }
 	| { type: 'chat'; message: string };
 
 export function getIntention(message: string, context: AIContext): Intent {
 	const lowerCaseMessage = message.toLowerCase();
+
+	// Terminal Commands
+	const runInTerminalMatch = lowerCaseMessage.match(/(?:run|execute|perform)(?: in terminal)?\s*`([^`]+)`/);
+	if (runInTerminalMatch) {
+		return { type: 'runInTerminal', command: runInTerminalMatch[1] };
+	}
+	const runInTerminalMatch2 = lowerCaseMessage.match(/^(?:run|execute|perform)\s+(.*)/);
+    if (runInTerminalMatch2 && !runInTerminalMatch2[1].startsWith('git')) { // Avoid clashing with git commands
+        return { type: 'runInTerminal', command: runInTerminalMatch2[1] };
+    }
 
 	// Git Operations
 	if (lowerCaseMessage.includes('status')) { // More flexible

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 let panel: vscode.WebviewPanel | undefined = undefined;
+let terminal: vscode.Terminal | undefined = undefined;
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -192,6 +193,24 @@ export function activate(context: vscode.ExtensionContext) {
 										}
 									} else {
 										panel?.webview.postMessage({ command: 'aiResponse', text: 'Push cancelled.' });
+									}
+									break;
+								case 'runInTerminal':
+									const termConfirm = await vscode.window.showWarningMessage(
+										`Are you sure you want to run the following command in the terminal?\n\n` +
+										`\`${intent.command}\``,
+										{ modal: true },
+										'Yes, run it'
+									);
+									if (termConfirm === 'Yes, run it') {
+										if (!terminal || terminal.exitStatus) {
+											terminal = vscode.window.createTerminal('Sense AI');
+										}
+										terminal.show();
+										terminal.sendText(intent.command);
+										panel?.webview.postMessage({ command: 'aiResponse', text: `I've sent the command \`${intent.command}\` to the terminal.` });
+									} else {
+										panel?.webview.postMessage({ command: 'aiResponse', text: 'Command execution cancelled.' });
 									}
 									break;
 								case 'generate':

--- a/src/test/intention.test.ts
+++ b/src/test/intention.test.ts
@@ -90,4 +90,13 @@ suite('Intention Recognition Test Suite', () => {
 		const intent = getIntention('push my changes', context);
 		assert.deepStrictEqual(intent, { type: 'gitPush' });
 	});
+
+	test('should identify a run in terminal intent', () => {
+		const context: AIContext = {};
+		let intent = getIntention('run `npm install` in the terminal', context);
+		assert.deepStrictEqual(intent, { type: 'runInTerminal', command: 'npm install' });
+
+		intent = getIntention('execute the tests', context);
+		assert.deepStrictEqual(intent, { type: 'runInTerminal', command: 'the tests' });
+	});
 });


### PR DESCRIPTION
This commit gives the Sense AI assistant a major new capability: the ability to run shell commands in the integrated terminal.

The AI can now understand natural language commands like "run `npm install`" or "execute the tests". This transforms the assistant from a code helper into a true interactive agent that can manage a development workflow.

Key features:
- The `getIntention` function has been enhanced to recognize a `runInTerminal` intent and parse the command.
- The extension uses the `vscode.window.createTerminal` API to manage a dedicated terminal instance.
- To ensure user safety, a confirmation dialog is shown before executing any command in the terminal.

Unit tests have been added to verify the new intent recognition capabilities.